### PR TITLE
FIx issue where primary bind has mod but secondary doesn't

### DIFF
--- a/dev_autopilot.py
+++ b/dev_autopilot.py
@@ -288,6 +288,8 @@ def get_bindings(keysToObtain=None):
                 new_key = item[1].attrib['Key']
                 if len(item[1]) > 0:
                     mod = item[1][0].attrib['Key']
+               else:
+                    mod = None
             # Adequate key to SCANCODE dict standard
             if new_key in convert_to_direct_keys:
                 new_key = convert_to_direct_keys[new_key]

--- a/dev_autopilot.py
+++ b/dev_autopilot.py
@@ -288,7 +288,7 @@ def get_bindings(keysToObtain=None):
                 new_key = item[1].attrib['Key']
                 if len(item[1]) > 0:
                     mod = item[1][0].attrib['Key']
-               else:
+                else:
                     mod = None
             # Adequate key to SCANCODE dict standard
             if new_key in convert_to_direct_keys:


### PR DESCRIPTION
Original code will try to use primary's mod with secondary's key 